### PR TITLE
Fixes issue #4 - Caused by a null value

### DIFF
--- a/templates/vsphere_management_network.ps1.j2
+++ b/templates/vsphere_management_network.ps1.j2
@@ -157,6 +157,7 @@ if ($dpg -ne $ManagementNetwork) {
   }
   else {
     "$dpg Does Not Exist so creating it On $vmhost" | Out-File -Append {{ vsphere_management_log }}
+    $dpgvs=$DesiredVswitch
     New-VirtualPortGroup -Server $vmHost -VirtualSwitch $dpgvs -Name $dpg -VLanId $pgVlanId -Confirm:$false | Out-File -Append {{ vsphere_management_log }}
   }
 }


### PR DESCRIPTION
The issue was that when building a host from scratch and a new vSwitch
was created there was not a reference for an existing location of the
portgroup. This resolves that issue with issue #4.

Signed-off-by: Larry Smith Jr <mrlesmithjr@gmail.com>