### PR TITLE
First Commit Of iSCSI Software Management

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,12 +53,6 @@ vsphere_bootstrap_vms_secure_password_file: c:\tmp\pwd.txt
 
 vsphere_bootstrap_vms_wait_for_ssh: "{{ vsphere_vms_wait_for_ssh }}"
 
-vsphere_datastores: []
-  # - name: Datastore_1
-  #   type: NFS
-  #   path: /TANK/NFS/vSphere/Datastore_1
-  #   host: 10.0.101.50
-
 # These define the IP addresses for the DDI VMs
 vsphere_ddi_vm_ips: []
   # - "{{ vsphere_vm_services_subnet }}.10"
@@ -211,6 +205,10 @@ vsphere_hosts_join_domain: false
 # Defines inventory directory
 vsphere_inventory_directory: ../inventory
 
+# Define any iSCSI Targets for Software iSCSI adapter
+vsphere_iscsi_targets: []
+  # - 10.0.101.50
+
 vsphere_lb_vips: []
   # - 10.0.101.100
 
@@ -256,6 +254,12 @@ vsphere_linux_vapp_template_name: ubuntu-16.04-template
 vsphere_maintenance_mode: false
 
 vsphere_management_invalid_certs_action: Ignore
+
+vsphere_nfs_datastores: []
+  # - name: Datastore_1
+  #   type: NFS
+  #   path: /TANK/NFS/vSphere/Datastore_1
+  #   host: 10.0.101.50
 
 vsphere_ntp_servers: []
   # - "{{ vsphere_ddi_vm_ips[0] }}"

--- a/inventory/group_vars/all/environment.yml
+++ b/inventory/group_vars/all/environment.yml
@@ -79,12 +79,14 @@ vsphere_samba_vms_memory: 512
 # Define Site Name
 vsphere_site_name: LAB
 
+vsphere_validate_certs: false
+
 # Defines the directory where the VCSA ISO has been extracted to
 vsphere_vcsa_iso_directory: C:\vagrant\vApps\VCSA_ISO
 
 #vSphere VM Services info
 # Defines the vSphere datastore to store vm core services on
-vsphere_vm_services_datastore: Datastore_1
+vsphere_vm_services_datastore: vSphere_iSCSI_Datastore_1
 # vSphere core services for vms
 vsphere_vm_services_subnet: 10.0.102
 vsphere_vm_services_subnet_mask: 255.255.255.0

--- a/inventory/group_vars/all/vsphere_datastores.yml
+++ b/inventory/group_vars/all/vsphere_datastores.yml
@@ -1,6 +1,16 @@
 ---
-vsphere_datastores:
-  - name: Datastore_1
-    type: NFS
-    path: /TANK/NFS/vSphere/Datastore_1
-    host: 10.0.101.50
+# Defines if unclaimed LUNs are auto partitioned and added as a new datastore
+vsphere_auto_create_datastores: true
+
+# Defines whether an iSCSI datastore cluster should be created
+vsphere_iscsi_datastore_cluster:
+  automation_level: FullyAutomated
+  io_load_balance: false
+  name: "{{ vsphere_vcenter_datacenter['name'] }}-SDRS-iSCSI-Cluster"
+  state: present
+
+vsphere_nfs_datastores: []
+  # - name: Datastore_1
+  #   type: NFS
+  #   path: /TANK/NFS/vSphere/Datastore_1
+  #   host: 10.0.101.50

--- a/inventory/group_vars/all/vsphere_updates.yml
+++ b/inventory/group_vars/all/vsphere_updates.yml
@@ -1,14 +1,14 @@
 ---
-vsphere_updates:
-  - build: 4192238
-    path: /vmfs/volumes/Datastore_1/ESXi600-201608001
-    version: 6.0.0
-  - build: 5050593
-    path: /vmfs/volumes/Datastore_1/update-from-esxi6.0-6.0_update03
-    version: 6.0.0
-  # - build: 5050593
-  #   path: /vmfs/volumes/Datastore_1/VMware-ESXi-6.0.0-Update3-5224934-HPE-600.10.1.0.73-Jul2017-depot
+vsphere_updates: []
+  # - build: 4192238
+  #   path: /vmfs/volumes/Datastore_1/ESXi600-201608001
   #   version: 6.0.0
-  - build: 5572656
-    path: /vmfs/volumes/Datastore_1/ESXi600-201706001
-    version: 6.0.0
+  # - build: 5050593
+  #   path: /vmfs/volumes/Datastore_1/update-from-esxi6.0-6.0_update03
+  #   version: 6.0.0
+  # # - build: 5050593
+  # #   path: /vmfs/volumes/Datastore_1/VMware-ESXi-6.0.0-Update3-5224934-HPE-600.10.1.0.73-Jul2017-depot
+  # #   version: 6.0.0
+  # - build: 5572656
+  #   path: /vmfs/volumes/Datastore_1/ESXi600-201706001
+  #   version: 6.0.0

--- a/scripts/vsphere_management.sh
+++ b/scripts/vsphere_management.sh
@@ -141,7 +141,8 @@ deploy_all()
   vsphere_ad_domain
   vsphere_vcsa
   vsphere_vcenter
-  vsphere_vcsa_ad
+  # vsphere_vcsa_ad
+  vsphere_management
   exit 0
 }
 

--- a/tasks/datastores.yml
+++ b/tasks/datastores.yml
@@ -1,17 +1,12 @@
 ---
-- name: datastores | Managing Datastores
-  win_shell: |
-    $vmHost="{{ hostvars[item]['ansible_host'] }}"
-    Connect-VIServer -Server $vmHost
-    Get-DataStore -Server $vmHost -refresh
-    $CurrentNFSDataStores=@($(Get-Datastore -Server $vmHost | Where {$_.type -eq "NFS"} | Select-Object -ExpandProperty Name))
-    {% for datastore in vsphere_datastores %}
-    {%   if datastore['type']|lower == 'nfs' %}
-    if ($CurrentNFSDataStores -notcontains '{{ datastore['name'] }}'){
-      New-Datastore -Server $vmHost -Nfs -Name '{{ datastore['name'] }}' -Path '{{ datastore['path'] }}' -NfsHost {{ datastore['host'] }}
-    {%   endif %}
-    }
-    {% endfor %}
-    Disconnect-VIServer * -Confirm:$false
-  with_items: "{{ groups['vsphere_hosts'] }}"
-  when: vsphere_datastores is defined
+- name: datastores | Generating Datastore Management Powershell Script
+  win_template:
+    src: vsphere_datastore_management.ps1.j2
+    dest: c:\tmp\vsphere_datastore_management.ps1
+
+- name: datastores | Executing Datastore Management Powershell Script
+  win_shell: c:\tmp\vsphere_datastore_management.ps1
+  failed_when: _vsphere_datastore_management_script_execution['stderr_lines'] != []
+  register: _vsphere_datastore_management_script_execution
+
+- debug: var=_vsphere_datastore_management_script_execution

--- a/tasks/iscsi.yml
+++ b/tasks/iscsi.yml
@@ -1,15 +1,12 @@
 ---
-- name: iscsi | Manage Software iSCSI Adapter
-  win_shell: |
-    $vmHost="{{ hostvars[item]['ansible_host'] }}"
-    Connect-VIServer -Server $vmHost
-    $vmHostStorage=(Get-VMHostStorage -Server $vmHost)
-    $SoftwareIScsiStatus="$($vmHostStorage | Select-Object -ExpandProperty SoftwareIScsiEnabled)"
-    $vmHostIScsiEnabled="{{ hostvars[item]['vsphere_enable_software_iscsi'] }}"
-    If ($SoftwareIScsiStatus -ne $vmHostIScsiEnabled) {
-      $vmHostStorage | Set-VMHostStorage -SoftwareIScsiEnabled ${{ hostvars[item]['vsphere_enable_software_iscsi'] }}
-      Start-Sleep -Seconds 30
-    }
-    Disconnect-VIServer * -Confirm:$false
-  with_items: "{{ groups['vsphere_hosts'] }}"
-  when: hostvars[item]['vsphere_enable_software_iscsi'] is defined
+- name: iscsi | Generating iSCSI Management Powershell Script
+  win_template:
+    src: vsphere_iscsi_management.ps1.j2
+    dest: c:\tmp\vsphere_iscsi_management.ps1
+
+- name: iscsi | Executing iSCSI Management Powershell Script
+  win_shell: c:\tmp\vsphere_iscsi_management.ps1
+  failed_when: _vsphere_iscsi_management_script_execution['stderr_lines'] != []
+  register: _vsphere_iscsi_management_script_execution
+
+- debug: var=_vsphere_iscsi_management_script_execution

--- a/templates/vsphere_datastore_management.ps1.j2
+++ b/templates/vsphere_datastore_management.ps1.j2
@@ -1,0 +1,75 @@
+{% for host in groups['vsphere_hosts'] %}
+$vmHost = "{{ hostvars[host]['ansible_host'] }}"
+Connect-VIServer -Server $vmHost
+
+$vmServer = Get-VMHost $vmHost
+
+{%   if vsphere_nfs_datastores is defined %}
+$vmServer | Get-Datastore -refresh
+$CurrentNFSDataStores = $vmServer | Get-Datastore | Where {$_.type -eq "NFS"}
+{%     for datastore in vsphere_nfs_datastores %}
+{%       if datastore['type']|lower == 'nfs' %}
+if ($CurrentNFSDataStores.Name -notcontains '{{ datastore['name'] }}'){
+  New-Datastore -Server $vmServer -Nfs -Name '{{ datastore['name'] }}' -Path '{{ datastore['path'] }}' -NfsHost {{ datastore['host'] }}
+{%       endif %}
+}
+{%     endfor %}
+{%  endif %}
+
+{%  if vsphere_auto_create_datastores %}
+$AllLuns = $vmServer | Get-ScsiLun -LunType disk
+$Datastores = $vmServer | Get-Datastore
+foreach ($lun in $AllLuns) {
+  $Datastore = $Datastores | Where-Object {$_.extensiondata.info.vmfs.extent.Diskname -Match $lun.CanonicalName}
+  if ($Datastore.Name -eq $null) {
+    $lunPath = $lun | Get-ScsiLunPath
+    $DatastoreName = $lunPath.SanId | ForEach-Object {$_.split(':')[1]} | ForEach-Object {$_.split('.')[1]} | Get-Unique
+    $CanonicalName = $lunPath.ScsiCanonicalName
+    $vmServer | New-Datastore -name $DatastoreName -Path $CanonicalName -Vmfs
+  }
+}
+{%   endif %}
+Disconnect-VIServer * -Confirm:$false
+{% endfor %}
+
+{% if _vsphere_vcenter_available and vsphere_iscsi_datastore_cluster is defined%}
+$vCenterHost = "{{ vsphere_vcsa_network_fqdn }}"
+Connect-VIServer $vCenterHost
+
+$vCenter = Get-VC $vCenterHost
+
+$Datacenter = "{{ vsphere_vcenter_datacenter['name'] }}"
+$Datastores = Get-Datastore -Server $vCenter
+$DatastoreClusters = Get-DatastoreCluster -Server $vCenter
+$DatastoreClusterName = "{{ vsphere_iscsi_datastore_cluster['name'] }}"
+$DatastoreClusterAutomationLevel = "{{ vsphere_iscsi_datastore_cluster['automation_level'] }}"
+$DatastoreClusterIOLoadBalance = ${{ vsphere_iscsi_datastore_cluster['io_load_balance'] }}
+{%   if vsphere_iscsi_datastore_cluster['state']|lower == "present" %}
+if ($DatastoreClusters.Name -notcontains $DatastoreClusterName) {
+  New-DatastoreCluster -Name $DatastoreClusterName -Location $Datacenter
+}
+
+$DatastoreCluster = Get-DatastoreCluster -Name $DatastoreClusterName
+if ($DatastoreCluster.SdrsAutomationLevel -ne $DatastoreClusterAutomationLevel) {
+  $DatastoreCluster | Set-DatastoreCluster -SdrsAutomationLevel $DatastoreClusterAutomationLevel -Confirm:$false
+}
+if ($DatastoreCluster.IOLoadBalanceEnabled -ne $DatastoreClusterIOLoadBalance) {
+  $DatastoreCluster | Set-DatastoreCluster -IOLoadBalanceEnabled $DatastoreClusterIOLoadBalance -Confirm:$false
+}
+
+$iSCSICanonicalNames = Get-VMHost -Server $vCenter | Get-VMHostHba -Type IScsi | Where {$_.Model -eq "iSCSI Software Adapter"} | Get-ScsiLun | Select-Object -ExpandProperty CanonicalName | Sort-Object | Get-Unique
+
+foreach ($iSCSICanonicalName in $iSCSICanonicalNames) {
+  $ClusterDatastores = Get-DatastoreCluster -Name $DatastoreClusterName -Location $Datacenter | Get-Datastore
+  $Datastore = $Datastores | Where-Object {$_.extensiondata.info.vmfs.extent.Diskname -Match $iSCSICanonicalName}
+  if ($ClusterDatastores.Name -notcontains $Datastore) {
+    Move-Datastore -Datastore $Datastore -Destination $DatastoreClusterName -Confirm:$false
+  }
+}
+{%   elif vsphere_iscsi_datastore_cluster['state']|lower == "absent" %}
+if ($DatastoreClusters.Name -contains $DatastoreClusterName) {
+  Get-DatastoreCluster -Name $DatastoreClusterName -Location $Datacenter | Remove-DatastoreCluster -Confirm:$false
+}
+{%   endif %}
+Disconnect-VIServer * -Confirm:$false
+{% endif %}

--- a/templates/vsphere_iscsi_management.ps1.j2
+++ b/templates/vsphere_iscsi_management.ps1.j2
@@ -1,0 +1,31 @@
+{% for host in groups['vsphere_hosts'] %}
+{%   if hostvars[host]['vsphere_enable_software_iscsi'] is defined %}
+$vmHost = "{{ hostvars[host]['ansible_host'] }}"
+Connect-VIServer -Server $vmHost
+$vmServer = Get-VMHost $vmHost
+$vmHostStorage = $vmServer | Get-VMHostStorage
+$SoftwareIScsiStatus = $vmHostStorage.SoftwareIScsiEnabled
+$vmHostIScsiEnabled = ${{ hostvars[host]['vsphere_enable_software_iscsi'] }}
+If ($SoftwareIScsiStatus -ne $vmHostIScsiEnabled) {
+  $vmHostStorage | Set-VMHostStorage -SoftwareIScsiEnabled $vmHostIScsiEnabled -Confirm:$false | Out-File -Append {{ vsphere_management_log }}
+  Start-Sleep -Seconds 30
+}
+
+{%     if hostvars[host]['vsphere_enable_software_iscsi'] %}
+{%       if vsphere_iscsi_targets is defined %}
+{%         for tgt in vsphere_iscsi_targets %}
+$HBATarget = "{{ tgt }}"
+$SoftwareIScsiAdapter = $vmServer | Get-VMHostHba -Type iScsi | Where {$_.Model -eq "iSCSI Software Adapter"}
+$SoftwareIScsiDevice = $SoftwareIScsiAdapter.Device
+$SoftwareIScsiHBATargets = $SoftwareIScsiAdapter | Get-IScsiHbaTarget | Select-Object -ExpandProperty Address
+if ($SoftwareIScsiHBATargets -notcontains $HBATarget) {
+  $SoftwareIScsiAdapter | New-IScsiHbaTarget -Address $HBATarget | Out-File -Append {{ vsphere_management_log }}
+}
+$vmServer | Get-VMHostStorage -RescanAllHba -RescanVmfs
+{%         endfor %}
+{%       endif %}
+{%     endif %}
+
+Disconnect-VIServer * -Confirm:$false
+{%   endif %}
+{% endfor %}


### PR DESCRIPTION
Currently we can:
 - enable/disable adapter
 - add target portal IPs
 - rescan HBA to discover LUNs
 - Gather all newly created LUNs and partition them if they are not
already, and add them as a new datastore based on SanId

Resolves #54